### PR TITLE
Do not require 'new' on initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@
 
 	var Chosen = function ($element, options) {
 
+		if (!(this instanceof Chosen)) return new Chosen($element, options);
+
 		this.$element = $element;
 
 		this.options.isMultiple = $element.getAttribute('multiple') === 'multiple';


### PR DESCRIPTION
Most common case I believe is to use Chosen as decorator, and then we may not need to keep instance object.

It would be great to allow just `Chosen(select)`, as doing `new Chosen(select)` without assignment looks weird, and breaks lint.
